### PR TITLE
Support for wrapped binaries (Support for base NixOS Gnome Shell process matching)

### DIFF
--- a/src/wsf_preload.c
+++ b/src/wsf_preload.c
@@ -89,6 +89,7 @@ static void *wsf_load_symbol(const char *name);
 static bool wsf_debug = false;
 static bool wsf_trace = false;
 static bool wsf_active = false;
+static bool wsf_is_launcher = false;
 static bool wsf_is_gnome_shell = false;
 static bool wsf_scroll_active = false;
 static bool wsf_gesture_active = false;
@@ -230,19 +231,17 @@ static void wsf_trace_scroll_event(
 	);
 }
 
-static bool wsf_target_list_contains(const char *targets, const char *name) {
+static bool wsf_target_list_matches(const char *targets) {
 	const char *cursor = targets;
-	size_t name_len = 0;
 
-	if (targets == NULL || targets[0] == '\0' ||
-		name == NULL || name[0] == '\0') {
+	if (targets == NULL || targets[0] == '\0') {
 		return false;
 	}
 
-	name_len = strlen(name);
 	while (*cursor != '\0') {
+		char token[256];
 		const char *start = NULL;
-		const char *end = NULL;
+		size_t token_len = 0;
 
 		while (*cursor == ',' || *cursor == ':' ||
 			isspace((unsigned char) *cursor)) {
@@ -257,28 +256,27 @@ static bool wsf_target_list_contains(const char *targets, const char *name) {
 			!isspace((unsigned char) *cursor)) {
 			cursor++;
 		}
-		end = cursor;
 
-		while (end > start && isspace((unsigned char) *(end - 1))) {
-			end--;
-		}
-
-		if ((size_t) (end - start) == name_len &&
-			strncmp(start, name, name_len) == 0) {
-			return true;
+		token_len = (size_t) (cursor - start);
+		if (token_len > 0 && token_len < sizeof(token)) {
+			memcpy(token, start, token_len);
+			token[token_len] = '\0';
+			if (wsf_proc_matches(token)) {
+				return true;
+			}
 		}
 	}
 
 	return false;
 }
 
-static void wsf_configure_activity(const char *proc_name) {
+static void wsf_configure_activity(void) {
 	const char *targets = getenv("WSF_TARGETS");
 	bool has_targets = targets != NULL && targets[0] != '\0';
-	bool is_gnome_shell = strcmp(proc_name, "gnome-shell") == 0;
-	bool is_hyprland = strcmp(proc_name, "Hyprland") == 0;
+	bool is_gnome_shell = wsf_proc_matches("gnome-shell");
+	bool is_hyprland = wsf_proc_matches("Hyprland");
 	bool targeted = has_targets ?
-		wsf_target_list_contains(targets, proc_name) :
+		wsf_target_list_matches(targets) :
 		is_gnome_shell;
 	bool hyprland_gestures = is_hyprland &&
 		(targeted ||
@@ -546,7 +544,7 @@ static void wsf_init_internal(void) {
 	if (!wsf_proc_name(proc_name, sizeof(proc_name))) {
 		snprintf(proc_name, sizeof(proc_name), "unknown");
 	}
-	wsf_configure_activity(proc_name);
+	wsf_configure_activity();
 	wsf_apply_effective_factors(false);
 	wsf_real_scroll_value =
 		(wsf_scroll_value_fn) wsf_load_symbol(
@@ -585,8 +583,35 @@ static void wsf_init_internal(void) {
 			"libinput_event_gesture_get_angle_delta"
 		);
 
+	/*
+	 * Launcher/wrapper detection: some distros install the compositor
+	 * behind a wrapper that execs the real binary (e.g. nixpkgs installs
+	 * bin/gnome-shell as a wrapper around .gnome-shell-wrapped). The
+	 * wrapper process is named like the target but does not link
+	 * libinput, so none of the real symbols resolve. Treat it as a
+	 * launcher: stay inactive and keep LD_PRELOAD intact so the exec'd
+	 * child (the real compositor) still loads the preload.
+	 */
+	if (wsf_active &&
+		wsf_real_event_type == NULL &&
+		wsf_real_base_event == NULL &&
+		wsf_real_scroll_value == NULL &&
+		wsf_real_axis_value == NULL) {
+		wsf_debug_log(
+			"init: target name matched but libinput is not loaded; "
+			"assuming launcher, preserving LD_PRELOAD for children"
+		);
+		wsf_is_launcher = true;
+		wsf_active = false;
+		wsf_scroll_active = false;
+		wsf_gesture_active = false;
+		wsf_is_gnome_shell = false;
+	}
+
 	wsf_init_done = true;
-	wsf_prune_ld_preload_env();
+	if (!wsf_is_launcher) {
+		wsf_prune_ld_preload_env();
+	}
 	(void) wsf_config_snapshot(&config_mtime, &config_present);
 	wsf_config_seen = true;
 	wsf_config_present = config_present;

--- a/src/wsf_proc.c
+++ b/src/wsf_proc.c
@@ -4,6 +4,10 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
+
+/* Kernel TASK_COMM_LEN is 16 including the NUL terminator. */
+#define WSF_COMM_MAX 15
 
 static const char *wsf_basename(const char *path) {
 	const char *slash = strrchr(path, '/');
@@ -15,9 +19,41 @@ static const char *wsf_basename(const char *path) {
 	return slash + 1;
 }
 
-static bool wsf_read_comm(char *buf, size_t len) {
-	FILE *file = fopen("/proc/self/comm", "r");
+void wsf_proc_normalize_wrapper(char *name) {
+	size_t len = 0;
+	static const char suffix[] = "-wrapped";
+	const size_t suffix_len = sizeof(suffix) - 1;
 
+	if (name == NULL || name[0] != '.') {
+		return;
+	}
+
+	len = strlen(name);
+	if (len <= suffix_len + 1 ||
+		strcmp(name + len - suffix_len, suffix) != 0) {
+		return;
+	}
+
+	/* ".foo-wrapped" -> "foo" (nixpkgs makeWrapper convention) */
+	memmove(name, name + 1, len - 1);
+	name[len - 1 - suffix_len] = '\0';
+}
+
+static bool wsf_read_proc_file(
+	const char *pid_dir,
+	const char *leaf,
+	char *buf,
+	size_t len
+) {
+	char path[64];
+	FILE *file = NULL;
+
+	if (snprintf(path, sizeof(path), "/proc/%s/%s", pid_dir, leaf) >=
+		(int) sizeof(path)) {
+		return false;
+	}
+
+	file = fopen(path, "r");
 	if (file == NULL) {
 		return false;
 	}
@@ -30,72 +66,193 @@ static bool wsf_read_comm(char *buf, size_t len) {
 	fclose(file);
 
 	buf[strcspn(buf, "\n")] = '\0';
-	return true;
+	return buf[0] != '\0';
 }
 
-static bool wsf_read_cmdline(char *buf, size_t len) {
-	FILE *file = fopen("/proc/self/cmdline", "r");
+static bool wsf_read_comm_for(const char *pid_dir, char *buf, size_t len) {
+	return wsf_read_proc_file(pid_dir, "comm", buf, len);
+}
+
+static bool wsf_read_cmdline_name(
+	const char *pid_dir,
+	char *buf,
+	size_t len
+) {
+	char path[64];
+	char cmdline[256];
+	const char *name = NULL;
+	FILE *file = NULL;
 	size_t read_len = 0;
 
+	if (snprintf(path, sizeof(path), "/proc/%s/cmdline", pid_dir) >=
+		(int) sizeof(path)) {
+		return false;
+	}
+
+	file = fopen(path, "r");
 	if (file == NULL) {
 		return false;
 	}
 
-	read_len = fread(buf, 1, len - 1, file);
+	read_len = fread(cmdline, 1, sizeof(cmdline) - 1, file);
 	fclose(file);
 
 	if (read_len == 0) {
 		return false;
 	}
 
-	buf[read_len] = '\0';
+	cmdline[read_len] = '\0';
+	name = wsf_basename(cmdline);
+	if (name[0] == '\0') {
+		return false;
+	}
+
+	strncpy(buf, name, len - 1);
+	buf[len - 1] = '\0';
 	return true;
 }
 
-bool wsf_proc_name(char *buf, size_t len) {
-	char cmdline[256];
+static bool wsf_read_exe_name(const char *pid_dir, char *buf, size_t len) {
+	char path[64];
+	char target[512];
 	const char *name = NULL;
+	ssize_t link_len = 0;
 
+	if (snprintf(path, sizeof(path), "/proc/%s/exe", pid_dir) >=
+		(int) sizeof(path)) {
+		return false;
+	}
+
+	link_len = readlink(path, target, sizeof(target) - 1);
+	if (link_len <= 0) {
+		return false;
+	}
+	target[link_len] = '\0';
+
+	/* readlink reports deleted binaries as "path (deleted)". */
+	if (link_len > 10 &&
+		strcmp(target + link_len - 10, " (deleted)") == 0) {
+		target[link_len - 10] = '\0';
+	}
+
+	name = wsf_basename(target);
+	if (name[0] == '\0') {
+		return false;
+	}
+
+	strncpy(buf, name, len - 1);
+	buf[len - 1] = '\0';
+	return true;
+}
+
+static bool wsf_comm_equals_target(const char *comm, const char *target) {
+	char candidate[256];
+
+	if (strcmp(comm, target) == 0) {
+		return true;
+	}
+
+	/*
+	 * comm is truncated to WSF_COMM_MAX characters by the kernel, so a
+	 * long target ("gnome-shell-calendar-server") or a wrapped binary
+	 * (".gnome-shell-wrapped" -> ".gnome-shell-wr") never compares equal
+	 * directly. Accept comm when it equals the truncation of either the
+	 * target itself or its wrapped form.
+	 */
+	if (strlen(comm) == WSF_COMM_MAX) {
+		if (strncmp(comm, target, WSF_COMM_MAX) == 0 &&
+			strlen(target) > WSF_COMM_MAX) {
+			return true;
+		}
+
+		if (snprintf(candidate, sizeof(candidate), ".%s-wrapped",
+			target) < (int) sizeof(candidate) &&
+			strncmp(comm, candidate, WSF_COMM_MAX) == 0 &&
+			strlen(candidate) > WSF_COMM_MAX) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static bool wsf_name_equals_target(const char *name, const char *target) {
+	char normalized[256];
+
+	if (strcmp(name, target) == 0) {
+		return true;
+	}
+
+	strncpy(normalized, name, sizeof(normalized) - 1);
+	normalized[sizeof(normalized) - 1] = '\0';
+	wsf_proc_normalize_wrapper(normalized);
+
+	return strcmp(normalized, target) == 0;
+}
+
+static bool wsf_pid_dir_matches(const char *pid_dir, const char *target) {
+	char name[256];
+
+	if (target == NULL || target[0] == '\0') {
+		return false;
+	}
+
+	if (wsf_read_exe_name(pid_dir, name, sizeof(name)) &&
+		wsf_name_equals_target(name, target)) {
+		return true;
+	}
+
+	if (wsf_read_comm_for(pid_dir, name, sizeof(name)) &&
+		wsf_comm_equals_target(name, target)) {
+		return true;
+	}
+
+	if (wsf_read_cmdline_name(pid_dir, name, sizeof(name)) &&
+		wsf_name_equals_target(name, target)) {
+		return true;
+	}
+
+	return false;
+}
+
+bool wsf_proc_name(char *buf, size_t len) {
 	if (buf == NULL || len == 0) {
 		return false;
 	}
 
 	buf[0] = '\0';
 
-	if (wsf_read_comm(buf, len)) {
+	if (wsf_read_exe_name("self", buf, len)) {
+		wsf_proc_normalize_wrapper(buf);
 		return true;
 	}
 
-	if (!wsf_read_cmdline(cmdline, sizeof(cmdline))) {
+	if (wsf_read_comm_for("self", buf, len)) {
+		return true;
+	}
+
+	return wsf_read_cmdline_name("self", buf, len);
+}
+
+bool wsf_proc_matches(const char *target) {
+	return wsf_pid_dir_matches("self", target);
+}
+
+bool wsf_proc_pid_matches(int pid, const char *target) {
+	char pid_dir[32];
+
+	if (pid <= 0) {
 		return false;
 	}
 
-	name = wsf_basename(cmdline);
-	strncpy(buf, name, len - 1);
-	buf[len - 1] = '\0';
-	return true;
+	if (snprintf(pid_dir, sizeof(pid_dir), "%d", pid) >=
+		(int) sizeof(pid_dir)) {
+		return false;
+	}
+
+	return wsf_pid_dir_matches(pid_dir, target);
 }
 
 bool wsf_proc_is_target(const char *target) {
-	char comm[256];
-	char cmdline[256];
-
-	if (target == NULL || target[0] == '\0') {
-		return false;
-	}
-
-	if (wsf_read_comm(comm, sizeof(comm))) {
-		if (strcmp(comm, target) == 0) {
-			return true;
-		}
-	}
-
-	if (wsf_read_cmdline(cmdline, sizeof(cmdline))) {
-		const char *name = wsf_basename(cmdline);
-		if (strcmp(name, target) == 0) {
-			return true;
-		}
-	}
-
-	return false;
+	return wsf_proc_matches(target);
 }

--- a/src/wsf_proc.h
+++ b/src/wsf_proc.h
@@ -7,4 +7,16 @@
 bool wsf_proc_name(char *buf, size_t len);
 bool wsf_proc_is_target(const char *target);
 
+/*
+ * Match the current process (or an arbitrary pid) against a target name,
+ * checking /proc exe, comm, and cmdline. Understands distro wrapper
+ * conventions (nixpkgs ".<name>-wrapped" binaries) and the kernel's
+ * 15-character comm truncation.
+ */
+bool wsf_proc_matches(const char *target);
+bool wsf_proc_pid_matches(int pid, const char *target);
+
+/* Strip the nixpkgs wrapper convention in place: ".foo-wrapped" -> "foo". */
+void wsf_proc_normalize_wrapper(char *name);
+
 #endif

--- a/tools/wsf.c
+++ b/tools/wsf.c
@@ -1462,7 +1462,9 @@ static int wsf_cmd_status(bool json) {
 		}
 
 		printf("{");
-		printf("\"enabled\":%s,", env_present ? "true" : "false");
+		printf("\"enabled\":%s,",
+			(env_present || runtime.user_manager_matches) ?
+			"true" : "false");
 		printf("\"env_file\":");
 		wsf_print_json_string(env_path);
 		printf(",");
@@ -1509,7 +1511,13 @@ static int wsf_cmd_status(bool json) {
 		return 0;
 	}
 
-	printf("enabled: %s\n", env_present ? "yes" : "no");
+	if (env_present) {
+		printf("enabled: yes\n");
+	} else if (runtime.user_manager_matches) {
+		printf("enabled: yes (system environment.d)\n");
+	} else {
+		printf("enabled: no\n");
+	}
 	printf("env file: %s (%s)\n", env_path, env_present ? "present" : "missing");
 	printf("library: %s (%s)\n", lib_path, lib_present ? "present" : "missing");
 	if (runtime.user_manager_ld_preload_present) {

--- a/tools/wsf.c
+++ b/tools/wsf.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 
 #include "wsf_config.h"
+#include "wsf_proc.h"
 
 #include <dirent.h>
 #include <errno.h>
@@ -1675,32 +1676,6 @@ static bool wsf_systemd_user_env_value(
 	return found;
 }
 
-static bool wsf_read_pid_comm(pid_t pid, char *buf, size_t len) {
-	char path[64];
-	FILE *file = NULL;
-
-	if (buf == NULL || len == 0 || pid <= 0) {
-		return false;
-	}
-
-	if (snprintf(path, sizeof(path), "/proc/%d/comm", (int) pid) >= (int) sizeof(path)) {
-		return false;
-	}
-
-	file = fopen(path, "r");
-	if (file == NULL) {
-		return false;
-	}
-
-	if (fgets(buf, (int) len, file) == NULL) {
-		fclose(file);
-		return false;
-	}
-
-	fclose(file);
-	buf[strcspn(buf, "\n")] = '\0';
-	return true;
-}
 
 static bool wsf_find_newest_pid_by_name(const char *name, pid_t *out_pid) {
 	DIR *dir = NULL;
@@ -1719,7 +1694,6 @@ static bool wsf_find_newest_pid_by_name(const char *name, pid_t *out_pid) {
 	while ((entry = readdir(dir)) != NULL) {
 		char *end = NULL;
 		long pid_long = 0;
-		char comm[128];
 
 		if (!isdigit((unsigned char) entry->d_name[0])) {
 			continue;
@@ -1732,10 +1706,7 @@ static bool wsf_find_newest_pid_by_name(const char *name, pid_t *out_pid) {
 		if (pid_long <= 0 || pid_long > INT_MAX) {
 			continue;
 		}
-		if (!wsf_read_pid_comm((pid_t) pid_long, comm, sizeof(comm))) {
-			continue;
-		}
-		if (strcmp(comm, name) != 0) {
+		if (!wsf_proc_pid_matches((int) pid_long, name)) {
 			continue;
 		}
 		if ((pid_t) pid_long > best) {


### PR DESCRIPTION
## Support compositors installed behind wrapper binaries (NixOS)

Fixes the investigation in #13 : WSF doesn't work on NixOS, and the failure isn't distro env-propagation, its from the gnome-shell binary being wrapped.

On NixOS, `bin/gnome-shell` is a small wrapper that execs the real binary,
`.gnome-shell-wrapped` (a common nixpkgs convention). That breaks WSF twice:

1. **The preload never survives the wrapper.** The wrapper process is *named* like the target (comm is `gnome-shell`), so WSF activates inside it and prunes its own `LD_PRELOAD` entry before the wrapper execs the real compositor, which therefore never loads the preload at all. This is why `LD_PRELOAD` was visible in `systemctl --user show-environment` but absent from gnome-shell's environment.

2. **The process guard can't match the real binary.** Its comm is  `.gnome-shell-wrapped`, kernel-truncated to `.gnome-shell-wr`, which never equals `gnome-shell`. `WSF_TARGETS` can't rescue it since scroll activation requires the built-in gnome-shell check. The CLI's `/proc` scan shares the same comparison, so `wsf status`/`repair` report "GNOME Shell has not loaded WSF" even while the library is mapped and scaling.

### Changes

- **proc:** match a target against `/proc/<pid>/exe` (normalizing the `.<name>-wrapped` convention), comm (truncation-aware), and argv0 — instead of exact-comm only.

- **preload:** detect launchers — if the process name matches a target but no libinput symbols resolve via `RTLD_NEXT`, it can't be the compositor; stay inactive and keep `LD_PRELOAD` for the exec'd child. Ordinary processes still prune exactly as before, so the sandboxed-app protection is unchanged.

- **cli:** locate the compositor with the same wrapper-aware matching.

- **cli:** report `enabled` when the user manager exports a matching `LD_PRELOAD` even without the per-user env file, so system-managed  `environment.d` installs (e.g. `/etc/environment.d` on NixOS) don't read as disabled. The GUI toggle picks this up via the existing JSON field; making the toggle read-only for system-managed installs is left as a follow-up.


Verified end-to-end on NixOS 26.05, GNOME 50, Wayland: plain `~/.config/environment.d` / `/etc/environment.d` delivery now works with no drop-ins or distro patches.

Once merged, the NixOS packaging I have created in my [fork](https://github.com/chrispouliot/wayland-scroll-factor/tree/nixos-flake) can be put up for PR as it is based on this so it doesn't need the manual post script patches