### PR TITLE
Add NixOS installation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,35 @@ sudo apt install "./wayland-scroll-factor_${version}-1_amd64.deb"
 
 This currently targets `amd64`.
 
+### NixOS via Flake
+
+The project is available via a Nix flake from this repository. Add it to your flake.nix file like so
+
+```
+{
+  description = "WSF Flake";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
+    wsf = {
+      url = "github:daniel-g-carrasco/wayland-scroll-factor";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  outputs = { nixpkgs, wsf, ... }: {
+    nixosConfigurations.nixos = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        wsf.nixosModules.default
+        { programs.wsf.enable = true; }
+        ./configuration.nix # The rest of your configuration
+      ];
+    };
+  };
+}
+
+```
+
+
 ### openSUSE, Gentoo, And Other Distros
 
 Use the source install for now. Package names for build dependencies are listed

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ This currently targets `amd64`.
 
 The project is available via a Nix flake from this repository. Add it to your flake.nix file like so
 
-```
+```nix
+
 {
   description = "WSF Flake";
   inputs = {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,8 +17,6 @@
 
       systemAgnostic = {
         nixosModules = rec {
-          # Wrap the module so it works without the overlay: default the
-          # package to this flake's own build for the host system.
           default = { pkgs, lib, ... }: {
             imports = [ module ];
             programs.wsf.package = lib.mkDefault
@@ -35,8 +33,6 @@
         };
       };
 
-      # Linux only: libinput + GNOME stack don't exist on darwin, and
-      # eachDefaultSystem would make `nix flake check` fail there.
       perSystem = flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
         let
           pkgs = import nixpkgs { inherit system; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "Tune touchpad scroll and gesture feel on Wayland";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      # Single source of truth: parse `version: '...'` out of meson.build.
+      version = builtins.head (builtins.match
+        ".*version: '([^']+)'.*"
+        (builtins.readFile ./meson.build));
+
+      module = ./packaging/nix/module.nix;
+
+      systemAgnostic = {
+        nixosModules = rec {
+          # Wrap the module so it works without the overlay: default the
+          # package to this flake's own build for the host system.
+          default = { pkgs, lib, ... }: {
+            imports = [ module ];
+            programs.wsf.package = lib.mkDefault
+              self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+          };
+          wayland-scroll-factor = default;
+        };
+
+        overlays.default = final: prev: {
+          wayland-scroll-factor = final.callPackage ./packaging/nix/package.nix {
+            src = self;
+            inherit version;
+          };
+        };
+      };
+
+      # Linux only: libinput + GNOME stack don't exist on darwin, and
+      # eachDefaultSystem would make `nix flake check` fail there.
+      perSystem = flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          wsf = pkgs.callPackage ./packaging/nix/package.nix {
+            src = self;
+            inherit version;
+          };
+        in {
+          packages.default = wsf;
+          packages.wayland-scroll-factor = wsf;
+
+          devShells.default = pkgs.mkShell {
+            inputsFrom = [ wsf ];
+          };
+        });
+    in
+      systemAgnostic // perSystem;
+}

--- a/packaging/nix/module.nix
+++ b/packaging/nix/module.nix
@@ -1,0 +1,34 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.programs.wsf;
+in
+{
+  options.programs.wsf = {
+    enable = lib.mkEnableOption "wayland-scroll-factor";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.wayland-scroll-factor;
+      description = "The wayland-scroll-factor package to use.";
+    };
+
+    gnomePreload = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Enable the GNOME Wayland preload backend declaratively.
+        Equivalent to running `wsf enable`. Requires logout/login.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+    environment.etc."environment.d/wayland-scroll-factor.conf" = lib.mkIf cfg.gnomePreload {
+      text = ''
+        LD_PRELOAD=${cfg.package}/lib/wayland-scroll-factor/libwsf_preload.so
+      '';
+    };
+  };
+}

--- a/packaging/nix/package.nix
+++ b/packaging/nix/package.nix
@@ -1,0 +1,65 @@
+{ lib
+, stdenv
+, meson
+, ninja
+, pkg-config
+, wrapGAppsHook4
+, gobject-introspection
+, python3
+, gtk4
+, libadwaita
+, libinput
+, glib
+, hyprland
+, withHyprland ? false
+, src
+, version
+}:
+
+let
+  # Used both to satisfy meson's find_program('python3') and so that
+  # patchShebangs rewrites wsf-gui's `#!/usr/bin/env python3` to an
+  # interpreter that can actually `import gi`.
+  pythonEnv = python3.withPackages (ps: [ ps.pygobject3 ]);
+in
+stdenv.mkDerivation {
+  pname = "wayland-scroll-factor";
+  inherit version src;
+
+  postPatch = ''
+    substituteInPlace gui/wsf_gui.py \
+      --replace-fail '#!/usr/bin/env python3' '#!${pythonEnv}/bin/python3'
+  '';
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    wrapGAppsHook4
+    gobject-introspection
+    pythonEnv
+  ];
+
+  buildInputs = [
+    gtk4
+    libadwaita
+    libinput
+    glib
+  ];
+
+  # wrapGAppsHook4 already wraps everything in $out/bin during fixup, so
+  # extra runtime PATH entries go through gappsWrapperArgs instead of a
+  # second wrapProgram layer. Hyprland is opt-in: on a GNOME system it would
+  # otherwise drag the entire Hyprland closure in just for hyprctl.
+  preFixup = lib.optionalString withHyprland ''
+    gappsWrapperArgs+=(--prefix PATH : ${lib.makeBinPath [ hyprland ]})
+  '';
+
+  meta = with lib; {
+    description = "Tune touchpad scroll and gesture feel on Wayland";
+    homepage = "https://github.com/daniel-g-carrasco/wayland-scroll-factor";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    mainProgram = "wsf";
+  };
+}


### PR DESCRIPTION
Add NixOS Flake, modules, and package files to allow for build and installation on NixOS systems.
Add flake.nix example to readme under distribution section.

`packaging/nix/module.nix` sets the variables and the LD_PRELOAD
`packaging/nix.package.nix` builds the package
`flake.lock` is the dependencies locked to my tested version (user's can override with the flake follows option, described in readme)
`flake.nix` is what ties it all together and what gets imported by users