### PR TITLE
ci: Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,14 @@
+// Renovate — same config as the margine repos: GHA digest pinning via
+// the best-practices preset, automerge for pure pin/digest updates.
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"],
+  "rebaseWhen": "never",
+  "packageRules": [
+    {
+      "description": "Auto-merge pure pin/digest updates",
+      "matchUpdateTypes": ["pin", "pinDigest"],
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
Same Renovate setup as the margine repos: `config:best-practices` (GHA digest pinning included) with automerge for pure pin/digest updates. No dependabot.yml existed here, so nothing to retire.