### PR TITLE
release: 0.3.4 (preload hardening)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wayland-scroll-factor',
   'c',
-  version: '0.3.3',
+  version: '0.3.4',
   default_options: [
     'warning_level=2',
     'c_std=c11',

--- a/packaging/rpm/wayland-scroll-factor.spec
+++ b/packaging/rpm/wayland-scroll-factor.spec
@@ -1,5 +1,5 @@
 Name:           wayland-scroll-factor
-Version:        0.3.3
+Version:        0.3.4
 Release:        1%{?dist}
 Summary:        Touchpad scroll and gesture tuning for Wayland
 
@@ -63,6 +63,17 @@ appstreamcli validate --no-net data/io.github.danielgrasso.WaylandScrollFactor.m
 %{_datadir}/wayland-scroll-factor/hyprland/wsf.lua
 
 %changelog
+* Sat Jun 13 2026 Daniel Grasso <daniel@the-empty.place> - 0.3.4-1
+- Preload hardening: thread-safe init (pthread_once) and atomic runtime
+  factors; stop re-reading/parsing the config on every 250 ms reload tick
+  during scrolling (only re-parse when the file actually changed).
+- Bounded config parsing (256-byte lines, 64 KiB file ceiling).
+- Atomic environment.d writes; `wsf enable` preserves foreign LD_PRELOAD;
+  WSF_LIB_PATH is validated before use.
+- Build hardening: PIE, stack-protector-strong, FORTIFY_SOURCE=2, RELRO,
+  hidden symbol visibility (only the 6 interposed libinput wrappers
+  exported).
+
 * Thu Jun 11 2026 Daniel Grasso <daniel@the-empty.place> - 0.3.3-1
 - Add GitHub Release asset workflow and package publication documentation.
 - Add RPM and Debian package build test automation.


### PR DESCRIPTION
Version bump for the **0.3.4** release that ships the preload hardening merged in #20 (thread-safety, the 250 ms hot-path reload fix, bounded config parsing, atomic env writes, WSF_LIB_PATH validation, PIE/RELRO/FORTIFY/visibility).

meson + spec version + RPM changelog only — no source changes. After merge I'll tag `v0.3.4` (triggers the release artifacts) and dispatch the COPR build.