### PR TITLE
feat: show the version everywhere (CLI, doctor/status, GUI About) — 0.3.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,16 +45,17 @@ jobs:
 
       - name: Static analysis (cppcheck)
         run: |
-          # -DWSF_LIBDIR mirrors meson's compile-time define (meson.build:
-          # `-DWSF_LIBDIR="<libdir>/wayland-scroll-factor"`, passed only to
-          # the tools target). Without it cppcheck explores the
-          # `#ifdef WSF_LIBDIR` branch with the macro auto-assumed as int 1,
-          # producing a bogus `%s requires char*` on the snprintf in
-          # wsf_lib_path. The value is irrelevant to the analysis; it only
-          # has to be the string literal the real build uses.
+          # -DWSF_LIBDIR / -DWSF_VERSION mirror meson's compile-time
+          # defines (passed to the tools target). Without them cppcheck
+          # explores the consuming branches with each macro auto-assumed
+          # as int 1, producing bogus `%s requires char*` warnings on the
+          # snprintf/printf that consume them. The values are irrelevant
+          # to the analysis; they only have to be the string literals the
+          # real build uses.
           cppcheck --enable=warning,performance,portability \
             --inline-suppr --error-exitcode=2 --quiet -I src \
             -DWSF_LIBDIR='"/usr/lib/wayland-scroll-factor"' \
+            -DWSF_VERSION='"0.0.0"' \
             src/ tools/wsf.c
 
       - name: Build (warnings are errors)

--- a/gui/wsf_gui.py
+++ b/gui/wsf_gui.py
@@ -10,7 +10,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, Gdk, GLib, Gtk
+from gi.repository import Adw, Gdk, Gio, GLib, Gtk
 
 APP_ID = "io.github.danielgrasso.WaylandScrollFactor"
 FACTOR_MIN = 0.05
@@ -35,6 +35,7 @@ class WsfWindow(Adw.ApplicationWindow):
         self.set_default_size(560, 640)
 
         self._cli_path = self._find_wsf()
+        self._version = self._get_version()
         self._debounce_ids = {}
         self._loading = True
         self._last_doctor_output = ""
@@ -52,7 +53,24 @@ class WsfWindow(Adw.ApplicationWindow):
 
         header = Adw.HeaderBar()
         header.set_show_end_title_buttons(True)
-        header.set_title_widget(Adw.WindowTitle(title="Wayland Scroll Factor"))
+        window_title = Adw.WindowTitle(title="Wayland Scroll Factor")
+        if self._version:
+            window_title.set_subtitle(f"v{self._version}")
+        header.set_title_widget(window_title)
+
+        # Primary menu with an About entry (version lives there too).
+        menu = Gio.Menu()
+        menu.append("About Wayland Scroll Factor", "win.about")
+        menu_button = Gtk.MenuButton()
+        menu_button.set_icon_name("open-menu-symbolic")
+        menu_button.set_menu_model(menu)
+        menu_button.set_tooltip_text("Main menu")
+        header.pack_end(menu_button)
+
+        about_action = Gio.SimpleAction.new("about", None)
+        about_action.connect("activate", self._on_about)
+        self.add_action(about_action)
+
         toolbar_view.add_top_bar(header)
 
         if not self._cli_path:
@@ -366,6 +384,39 @@ class WsfWindow(Adw.ApplicationWindow):
             )
         except OSError:
             return None
+
+    def _get_version(self):
+        # Single source of truth: ask the installed CLI, so the GUI can
+        # never disagree with the wsf binary it drives.
+        result = self._run_wsf(["version"])
+        if result and result.returncode == 0 and result.stdout:
+            parts = result.stdout.strip().split()
+            if parts:
+                return parts[-1]
+        return None
+
+    def _on_about(self, *_args):
+        version = self._version or "unknown"
+        kwargs = {
+            "application_name": "Wayland Scroll Factor",
+            "application_icon": APP_ID,
+            "version": version,
+            "developer_name": "Daniel Grasso",
+            "website": "https://github.com/daniel-g-carrasco/wayland-scroll-factor",
+            "issue_url": (
+                "https://github.com/daniel-g-carrasco/"
+                "wayland-scroll-factor/issues"
+            ),
+            "license_type": Gtk.License.MIT_X11,
+        }
+        # Adw.AboutDialog is the modern (libadwaita 1.5+) widget; fall back
+        # to Adw.AboutWindow on older runtimes (Debian stable, etc.).
+        if hasattr(Adw, "AboutDialog"):
+            about = Adw.AboutDialog(**kwargs)
+            about.present(self)
+        else:
+            about = Adw.AboutWindow(transient_for=self, **kwargs)
+            about.present()
 
     def _find_wsf(self):
         path = shutil.which("wsf")

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'wayland-scroll-factor',
   'c',
-  version: '0.3.4',
+  version: '0.3.5',
   default_options: [
     'warning_level=2',
     'c_std=c11',
@@ -34,6 +34,7 @@ add_project_link_arguments(hardening_link_args, language: 'c')
 
 wsf_libdir = join_paths(get_option('prefix'), get_option('libdir'), 'wayland-scroll-factor')
 wsf_libdir_define = '-DWSF_LIBDIR="' + wsf_libdir + '"'
+wsf_version_define = '-DWSF_VERSION="' + meson.project_version() + '"'
 
 subdir('src')
 subdir('tools')

--- a/packaging/debian/debian/changelog
+++ b/packaging/debian/debian/changelog
@@ -1,3 +1,11 @@
+wayland-scroll-factor (0.3.5-1) unstable; urgency=medium
+
+  * Show the version everywhere: wsf version / wsf --version, a
+    wsf_version field in status and doctor (text and --json), and a GTK
+    About dialog plus a version subtitle in the GUI.
+
+ -- Daniel Grasso <daniel@the-empty.place>  Sat, 13 Jun 2026 10:05:00 +0200
+
 wayland-scroll-factor (0.3.4-1) unstable; urgency=medium
 
   * Preload hardening: thread-safe init (pthread_once) and atomic runtime

--- a/packaging/rpm/wayland-scroll-factor.spec
+++ b/packaging/rpm/wayland-scroll-factor.spec
@@ -1,5 +1,5 @@
 Name:           wayland-scroll-factor
-Version:        0.3.4
+Version:        0.3.5
 Release:        1%{?dist}
 Summary:        Touchpad scroll and gesture tuning for Wayland
 
@@ -63,6 +63,11 @@ appstreamcli validate --no-net data/io.github.danielgrasso.WaylandScrollFactor.m
 %{_datadir}/wayland-scroll-factor/hyprland/wsf.lua
 
 %changelog
+* Sat Jun 13 2026 Daniel Grasso <daniel@the-empty.place> - 0.3.5-1
+- Show the version everywhere: `wsf version` / `wsf --version`, a
+  `wsf_version`/`wsf-version` field in `status` and `doctor` (text and
+  --json), and a GTK About dialog plus a version subtitle in the GUI.
+
 * Sat Jun 13 2026 Daniel Grasso <daniel@the-empty.place> - 0.3.4-1
 - Preload hardening: thread-safe init (pthread_once) and atomic runtime
   factors; stop re-reading/parsing the config on every 250 ms reload tick

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -5,7 +5,7 @@ executable(
   ['wsf.c', '../src/wsf_config.c', '../src/wsf_proc.c'],
   include_directories: wsf_inc,
   dependencies: [dl_dep],
-  c_args: [wsf_libdir_define],
+  c_args: [wsf_libdir_define, wsf_version_define],
   install: true,
   install_dir: join_paths(get_option('prefix'), get_option('bindir'))
 )

--- a/tools/wsf.c
+++ b/tools/wsf.c
@@ -19,6 +19,12 @@
 static bool wsf_run_command(const char *cmd, char *buf, size_t len);
 static bool wsf_run_command_ok(const char *cmd);
 
+/* Project version, injected by meson (-DWSF_VERSION="x.y.z"). The
+ * fallback keeps a hand-run gcc build compiling. */
+#ifndef WSF_VERSION
+#define WSF_VERSION "unknown"
+#endif
+
 #define WSF_HYPRLAND_SCROLL_FACTOR_MAX 2.0
 #define WSF_ENV_VALUE_MAX 32768
 
@@ -864,6 +870,7 @@ static void wsf_print_usage(const char *prog) {
 	fprintf(stderr, "  disable        Disable preload via environment.d\n");
 	fprintf(stderr, "  status [--json] Show current status\n");
 	fprintf(stderr, "  doctor [--json] Print diagnostics\n");
+	fprintf(stderr, "  version        Print the wayland-scroll-factor version\n");
 }
 
 static bool wsf_parse_factor_arg(const char *arg, double *out_factor) {
@@ -1523,6 +1530,9 @@ static int wsf_cmd_status(bool json) {
 		}
 
 		printf("{");
+		printf("\"wsf_version\":");
+		wsf_print_json_string(WSF_VERSION);
+		printf(",");
 		printf("\"enabled\":%s,",
 			(env_present || runtime.user_manager_matches) ?
 			"true" : "false");
@@ -1572,6 +1582,7 @@ static int wsf_cmd_status(bool json) {
 		return 0;
 	}
 
+	printf("wsf version: %s\n", WSF_VERSION);
 	if (env_present) {
 		printf("enabled: yes\n");
 	} else if (runtime.user_manager_matches) {
@@ -2196,6 +2207,9 @@ static int wsf_cmd_doctor(bool json) {
 
 	if (json) {
 		printf("{");
+		printf("\"wsf_version\":");
+		wsf_print_json_string(WSF_VERSION);
+		printf(",");
 		printf("\"session\":");
 		wsf_print_json_string(session);
 		printf(",");
@@ -2307,6 +2321,7 @@ static int wsf_cmd_doctor(bool json) {
 		return 0;
 	}
 
+	wsf_print_kv("wsf-version", WSF_VERSION);
 	wsf_print_kv("session", session);
 	wsf_print_kv("desktop", desktop);
 	if (wsf_run_command("gnome-shell --version 2>/dev/null", gnome, sizeof(gnome))) {
@@ -2450,6 +2465,12 @@ int main(int argc, char **argv) {
 	}
 
 	cmd = argv[1];
+	if (strcmp(cmd, "version") == 0 ||
+	    strcmp(cmd, "--version") == 0 ||
+	    strcmp(cmd, "-V") == 0) {
+		printf("wayland-scroll-factor %s\n", WSF_VERSION);
+		return 0;
+	}
 	if (strcmp(cmd, "set") == 0) {
 		if (argc < 3) {
 			fprintf(stderr, "Missing factor.\n");


### PR DESCRIPTION
Closes the 'which version am I running?' gap — there was no version output anywhere (`wsf --version` was `Unknown command`).

**Version is now shown in all three places** (as suggested):
- **CLI**: `wsf version` (+ `--version`/`-V`).
- **doctor / status**: a `wsf_version` field in both human and `--json` output.
- **GUI**: a GTK **About dialog** (Adw.AboutDialog → Adw.AboutWindow fallback) from a primary menu, plus the version as the **header subtitle**.

One source of truth: the version is injected by meson (`-DWSF_VERSION=project_version()`, `unknown` fallback for hand-run gcc), and the GUI asks the CLI (`wsf version`) so it can never disagree with the binary it drives. cppcheck gets the define too so the new `%s` printfs stay clean.

Bumps to **0.3.5** (meson + rpm spec + debian changelog). Verified: `-Werror` compile, `wsf version`/`doctor`/`status --json` all report the version, GUI `py_compile`, cppcheck 2.13 clean in an ubuntu:24.04 container.