### PR TITLE
ci: automated AUR publishing on tags + a distrobox GUI dev loop

### DIFF
--- a/.github/scripts/aur-publish.sh
+++ b/.github/scripts/aur-publish.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Publish the stable + -git packages to the AUR. Runs as the unprivileged
+# 'builder' user INSIDE an archlinux container (makepkg refuses root), with
+# ~/.ssh/aur = the AUR deploy key already in place. Invoked by
+# .github/workflows/aur.yml.
+#
+# - stable (wayland-scroll-factor): pkgver/pkgrel/sha256 are pinned from the
+#   release tarball of the triggering vX.Y.Z tag, then .SRCINFO is regenerated
+#   and pushed.
+# - -git (wayland-scroll-factor-git): published as-is (its pkgver() derives the
+#   version at build time on the user's machine); kept current so a PKGBUILD
+#   change reaches the AUR too. A no-op push when nothing changed.
+#
+# The AUR packages must already exist and the deploy key's account must be a
+# (co-)maintainer. TAG is provided by the workflow (e.g. v0.3.5).
+set -euo pipefail
+
+TAG="${TAG:?TAG (vX.Y.Z) is required}"
+VER="${TAG#v}"
+REPO_ROOT="${REPO_ROOT:-/work}"
+WORK="${WORK:-$HOME/aur-work}"
+PROJECT_URL="https://github.com/daniel-g-carrasco/wayland-scroll-factor"
+
+git config --global user.name "wsf release bot"
+git config --global user.email "ai@danielgrasso.com"
+
+mkdir -p "$WORK"
+cd "$WORK"
+
+# Publish one AUR package: clone (or init if it does not exist yet), copy the
+# packaging files, regenerate .SRCINFO, commit + push only when something
+# actually changed.
+publish() {
+	local aur_name="$1" src_dir="$2"
+	local remote="ssh://aur@aur.archlinux.org/${aur_name}.git"
+
+	echo "==> ${aur_name}"
+	rm -rf "$aur_name"
+	if ! git clone "$remote" "$aur_name" 2>/dev/null; then
+		echo "    repo not on AUR yet — initialising a new one"
+		mkdir -p "$aur_name"
+		git -C "$aur_name" init -q
+		git -C "$aur_name" remote add origin "$remote"
+	fi
+
+	cp "$REPO_ROOT/$src_dir/PKGBUILD" "$aur_name/PKGBUILD"
+	if [ -f "$REPO_ROOT/$src_dir/wayland-scroll-factor.install" ]; then
+		cp "$REPO_ROOT/$src_dir/wayland-scroll-factor.install" "$aur_name/"
+	fi
+
+	( cd "$aur_name" && makepkg --printsrcinfo > .SRCINFO )
+
+	git -C "$aur_name" add -A
+	if git -C "$aur_name" diff --cached --quiet; then
+		echo "    no changes — nothing to push"
+		return 0
+	fi
+	git -C "$aur_name" commit -q -m "Update to ${VER}"
+	git -C "$aur_name" push -u origin HEAD:master
+	echo "    pushed ${aur_name} @ ${VER}"
+}
+
+# --- stable: pin version + checksum from the release tarball ---
+tarball_url="${PROJECT_URL}/archive/refs/tags/${TAG}.tar.gz"
+echo "Hashing release tarball: ${tarball_url}"
+sha="$(curl -fsSL "$tarball_url" | sha256sum | cut -d' ' -f1)"
+[ -n "$sha" ] || { echo "failed to hash release tarball" >&2; exit 1; }
+
+sed -i \
+	-e "s/^pkgver=.*/pkgver=${VER}/" \
+	-e "s/^pkgrel=.*/pkgrel=1/" \
+	-e "s/^sha256sums=.*/sha256sums=('${sha}')/" \
+	"$REPO_ROOT/packaging/aur-stable/PKGBUILD"
+
+publish "wayland-scroll-factor" "packaging/aur-stable"
+
+# --- -git: publish as-is (version is computed at build time) ---
+publish "wayland-scroll-factor-git" "packaging/aur"
+
+echo "AUR publish complete for ${TAG}"

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -1,0 +1,96 @@
+name: Publish AUR
+
+# Publishes the stable package on every clean semver tag (vX.Y.Z), the same
+# way COPR ships the Fedora package — but fully automatic on the tag rather
+# than a manual dispatch. Pre-release tags (v1.2.3-rc1, …) are skipped. The
+# -git package is refreshed alongside so a PKGBUILD change reaches the AUR too.
+#
+# workflow_dispatch is kept for bootstrapping / re-publishing an existing tag
+# if a push failed (it does not change the normal automatic-on-tag flow).
+#
+# Requires the AUR_SSH_KEY secret: the PRIVATE half of an SSH key whose public
+# half is registered on an AUR account that (co-)maintains both packages.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to (re)publish, e.g. v0.3.5"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aur-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to AUR
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Resolve tag
+        id: tag
+        env:
+          DISPATCH_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${DISPATCH_TAG:-}" ]; then
+            tag="$DISPATCH_TAG"
+          else
+            tag="${GITHUB_REF_NAME}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          # Skip pre-releases (anything with a '-' after the version).
+          if [[ "$tag" == *-* ]]; then
+            echo "Pre-release tag '$tag' — skipping AUR publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out the tag
+        if: steps.tag.outputs.skip != 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Publish (stable + -git) to the AUR
+        if: steps.tag.outputs.skip != 'true'
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AUR_SSH_KEY:-}" ]; then
+            echo "::error::Missing AUR_SSH_KEY secret (private deploy key for the AUR account)."
+            exit 1
+          fi
+          mkdir -p aur-ssh
+          printf '%s\n' "$AUR_SSH_KEY" > aur-ssh/aur
+          chmod 600 aur-ssh/aur
+
+          docker run --rm \
+            -v "$PWD:/work" \
+            -v "$PWD/aur-ssh:/aur-ssh:ro" \
+            -e TAG \
+            docker.io/library/archlinux:latest \
+            bash -c '
+              set -euo pipefail
+              pacman -Sy --noconfirm --needed base-devel git openssh curl
+              useradd -m builder
+              install -d -m 700 /home/builder/.ssh
+              cp /aur-ssh/aur /home/builder/.ssh/aur
+              chmod 600 /home/builder/.ssh/aur
+              ssh-keyscan -t ed25519,rsa aur.archlinux.org \
+                > /home/builder/.ssh/known_hosts 2>/dev/null
+              printf "Host aur.archlinux.org\n  User aur\n  IdentityFile ~/.ssh/aur\n  IdentitiesOnly yes\n" \
+                > /home/builder/.ssh/config
+              chown -R builder:builder /home/builder/.ssh /work
+              su builder -c "TAG=$TAG REPO_ROOT=/work /work/.github/scripts/aur-publish.sh"
+            '

--- a/docs/aur.md
+++ b/docs/aur.md
@@ -1,0 +1,46 @@
+# AUR Publishing
+
+WSF is published to the Arch User Repository as two packages:
+
+- **`wayland-scroll-factor`** — the stable package, built from a release
+  tarball. Source: `packaging/aur-stable/PKGBUILD`.
+- **`wayland-scroll-factor-git`** — the VCS package, built from `main` (its
+  `pkgver()` derives the version at build time). Source: `packaging/aur/PKGBUILD`.
+
+Publishing is automated by `.github/workflows/aur.yml` — the AUR counterpart of
+the COPR workflow (see [copr.md](copr.md)), but it runs **automatically on every
+clean semver tag** rather than on a manual dispatch.
+
+## How the automation works
+
+- On `git push` of a tag `vX.Y.Z` (no pre-release suffix), the workflow:
+  1. downloads the release tarball for that tag and computes its `sha256`,
+  2. pins `pkgver`/`pkgrel`/`sha256sums` in `packaging/aur-stable/PKGBUILD`,
+  3. regenerates `.SRCINFO` with `makepkg --printsrcinfo`,
+  4. pushes the stable package to the AUR,
+  5. refreshes `wayland-scroll-factor-git` from `packaging/aur/PKGBUILD` (a
+     no-op push when nothing changed).
+- Pre-release tags (`v1.2.3-rc1`, `…-beta`, …) are **skipped**.
+- `workflow_dispatch` (with a `tag` input) is available to bootstrap or
+  re-publish an existing tag if a push failed. It does not change the normal
+  automatic-on-tag flow.
+
+Tagging strategy: cut releases with clean `vMAJOR.MINOR.PATCH` tags (the same
+tags `release.yml` and the COPR build consume). The version itself lives in
+`meson.build`; bump it together with the RPM spec and the Debian changelog.
+
+## One-time setup
+
+1. Create an AUR account and register an SSH **public** key on it
+   (`https://aur.archlinux.org` → My Account → SSH Public Key). The account
+   must be the maintainer or a co-maintainer of **both** packages.
+
+2. Add the matching **private** key as a repository secret named
+   `AUR_SSH_KEY` (Settings → Secrets and variables → Actions). Use a key
+   dedicated to CI; it only needs AUR push access.
+
+3. The packages must already exist on the AUR (first submission is manual, or
+   the workflow will initialise a new repo on first push if the name is free
+   and the account is authorised).
+
+After that, every `vX.Y.Z` tag updates the AUR automatically.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,6 +9,22 @@ Containers are useful, but they cannot prove that libinput events are modified
 inside `gnome-shell` or `Hyprland`, and they cannot prove how a real Flatpak or
 Electron window consumes Wayland pointer-axis events.
 
+## Iterating on the GUI (distrobox)
+
+To work on the GUI without rebasing an atomic host or spinning up a VM:
+
+```bash
+scripts/dev-distrobox.sh create   # one-time: Ubuntu box + deps + first build
+scripts/dev-distrobox.sh build    # rebuild + reinstall after editing code
+scripts/dev-distrobox.sh gui      # launch wsf-gui on your session
+```
+
+distrobox shares `$HOME` and the Wayland socket, so the window opens on your
+host session. This exercises the GUI app (window, About dialog, sliders,
+toasts) and the CLI it drives — but **not** real scroll-injection behavior,
+which needs the compositor's own `gnome-shell` to load the preload (use a
+separate VM with a full GNOME session for that).
+
 ## Container Smoke Tests
 
 Use Podman from the repository root:

--- a/packaging/aur-stable/PKGBUILD
+++ b/packaging/aur-stable/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Daniel Grasso
 
 pkgname=wayland-scroll-factor
-pkgver=0.3.2
+pkgver=0.3.5
 pkgrel=1
 pkgdesc='Touchpad scroll and gesture tuning for Wayland (GNOME and Hyprland)'
 arch=('x86_64')
@@ -16,7 +16,7 @@ optdepends=(
 )
 install=wayland-scroll-factor.install
 source=("$pkgname-$pkgver.tar.gz::https://github.com/daniel-g-carrasco/wayland-scroll-factor/archive/refs/tags/v$pkgver.tar.gz")
-sha256sums=('d6c84957f371a2a5ec4c393661fab538d2f1328ee95cb0950e3f4732f039e48f')
+sha256sums=('59d49cf6e1ebbb5434db0c8f629e50830d33d09a6e6280458b9187f722f7f983')
 
 build() {
   cd "$pkgname-$pkgver"

--- a/scripts/dev-distrobox.sh
+++ b/scripts/dev-distrobox.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Disposable Ubuntu distrobox for iterating on the WSF GUI without touching
+# the host (or rebasing an atomic distro). distrobox shares $HOME and the
+# Wayland socket, so `wsf-gui` launched from the box opens on your host
+# session.
+#
+#   scripts/dev-distrobox.sh create   # one-time: make the box + deps + build
+#   scripts/dev-distrobox.sh build    # rebuild + reinstall wsf in the box
+#   scripts/dev-distrobox.sh gui      # launch the GUI from the box
+#   scripts/dev-distrobox.sh cli ...  # run the box's wsf with args
+#   scripts/dev-distrobox.sh enter    # shell into the box
+#   scripts/dev-distrobox.sh rm       # delete the box
+#
+# Typical loop: edit code -> `build` -> `gui`.
+#
+# SCOPE: this exercises the GUI APP (window, About dialog, sliders, toasts)
+# and the CLI it drives. It does NOT test real scroll-injection behaviour —
+# the preload has to be loaded by the compositor's own gnome-shell, which a
+# shared-session container does not give you. Use a separate VM for that.
+set -euo pipefail
+
+BOX="${WSF_DEV_BOX:-wsf-dev}"
+IMAGE="${WSF_DEV_IMAGE:-ubuntu:24.04}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="/tmp/wsf-dev-build-${BOX}"
+
+# Build + runtime deps. The C parts (preload + CLI) need only a toolchain;
+# the Python GUI needs the GTK4/libadwaita GObject introspection at runtime.
+DEPS=(
+  build-essential meson ninja-build pkg-config git
+  python3 python3-gi gir1.2-gtk-4.0 gir1.2-adw-1
+  libgtk-4-1 libadwaita-1-0 desktop-file-utils
+)
+
+need_distrobox() {
+  command -v distrobox >/dev/null 2>&1 && return 0
+  echo "distrobox not found. It ships with Bluefin/Bazzite; otherwise:" >&2
+  echo "  brew install distrobox   (or your distro's package)" >&2
+  exit 1
+}
+
+box_exists() { distrobox list 2>/dev/null | awk '{print $3}' | grep -qx "$BOX"; }
+
+cmd_create() {
+  need_distrobox
+  if box_exists; then
+    echo "Box '$BOX' already exists — installing deps + building."
+  else
+    echo "Creating box '$BOX' from $IMAGE ..."
+    distrobox create --yes --name "$BOX" --image "$IMAGE"
+  fi
+  distrobox enter "$BOX" -- bash -lc "
+    set -e
+    sudo apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ${DEPS[*]}
+  "
+  cmd_build
+  cat <<EOF
+
+Ready. Iterate with:
+  $0 build    # after editing code
+  $0 gui      # launch the GUI on your session
+EOF
+}
+
+cmd_build() {
+  need_distrobox
+  box_exists || { echo "Box '$BOX' does not exist — run: $0 create" >&2; exit 1; }
+  distrobox enter "$BOX" -- bash -lc "
+    set -e
+    cd '$ROOT'
+    rm -rf '$BUILD_DIR'
+    meson setup '$BUILD_DIR' --prefix=/usr --buildtype=debug
+    ninja -C '$BUILD_DIR'
+    sudo ninja -C '$BUILD_DIR' install
+    echo -n 'installed: '; wsf version
+  "
+}
+
+cmd_gui() {
+  need_distrobox
+  box_exists || { echo "Box '$BOX' does not exist — run: $0 create" >&2; exit 1; }
+  distrobox enter "$BOX" -- wsf-gui
+}
+
+cmd_cli() {
+  need_distrobox
+  box_exists || { echo "Box '$BOX' does not exist — run: $0 create" >&2; exit 1; }
+  distrobox enter "$BOX" -- wsf "$@"
+}
+
+cmd_enter() { need_distrobox; distrobox enter "$BOX"; }
+
+cmd_rm() {
+  need_distrobox
+  distrobox rm --force "$BOX" && echo "Removed box '$BOX'."
+}
+
+case "${1:-}" in
+  create) cmd_create ;;
+  build)  cmd_build ;;
+  gui)    cmd_gui ;;
+  cli)    shift; cmd_cli "$@" ;;
+  enter)  cmd_enter ;;
+  rm)     cmd_rm ;;
+  -h|--help|"")
+    sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  *)
+    echo "unknown command: $1" >&2
+    echo "run: $0 --help" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Two things you asked for.

## AUR auto-publish (like COPR, but better)
`.github/workflows/aur.yml` publishes to the AUR **automatically on every clean semver tag `vX.Y.Z`** (COPR is a manual dispatch; this is hands-off on the tag). Pre-release tags (`-rc1`, …) are skipped.

- Stable `wayland-scroll-factor`: pins `pkgver`/`pkgrel`/`sha256` from the release tarball, regenerates `.SRCINFO`, pushes.
- `wayland-scroll-factor-git`: refreshed alongside (no-op when unchanged).
- Work runs in an `archlinux` container as an unprivileged user (makepkg refuses root); logic in `.github/scripts/aur-publish.sh`.
- **Tag strategy**: cut releases with clean `vMAJOR.MINOR.PATCH` tags (the same ones `release.yml` + COPR already use); the version lives in `meson.build`, bumped with the spec + debian changelog. Pre-releases never hit AUR.
- **Setup needed (one-time)**: add an `AUR_SSH_KEY` secret = the private deploy key for an AUR account that (co-)maintains both packages. See `docs/aur.md`. Also refreshed `aur-stable/PKGBUILD` to 0.3.5 (was stale at 0.3.2).

To publish the current **0.3.5** to AUR after merge + adding the secret: run the workflow once via *Actions → Publish AUR → Run workflow → tag = v0.3.5* (bootstrap), then it's automatic for every future tag.

## distrobox GUI dev loop
`scripts/dev-distrobox.sh` — iterate on the GUI without rebasing your atomic host or running a VM:
```
scripts/dev-distrobox.sh create   # one-time
scripts/dev-distrobox.sh build    # after editing
scripts/dev-distrobox.sh gui
```
Shares $HOME + the Wayland socket so the window opens on your session. Exercises the GUI app + CLI; documented that it does **not** test real scroll injection (needs a full GNOME session). 

Lint: shellcheck + actionlint clean.